### PR TITLE
ACT-455: Replace SiteProfile Map View with OSM + Leaflet.js

### DIFF
--- a/templates/workflow/site_profile_map.html
+++ b/templates/workflow/site_profile_map.html
@@ -149,45 +149,29 @@
 
 	let locations = [];
 
-	let marker_nairobi = L.marker([Number('-1.2921'), Number('36.8219')], {
-		draggable:false
-	});
-	marker_nairobi.addTo(map);
-	locations.push(marker_nairobi);
-	marker_nairobi.url = 'https://en.wikipedia.org/wiki/Nairobi'
-	marker_nairobi.on('click', function(){
-		window.location = (this.url);
-	})
+	//for each site we create a marker, add it to the map and a list
+	{% for site in get_site_profile %}
+		let marker{{ forloop.counter0 }} = L.marker([Number('{{site.latitude}}'), Number('{{site.longitude}}')], {
+				draggable:false
+		});
 
-	let marker_berlin = L.marker([Number('52.5200'), Number('13.4050')], {
-		draggable:false
-	});
-	marker_berlin.addTo(map);
-	locations.push(marker_berlin);
-	marker_berlin.url = 'https://en.wikipedia.org/wiki/Berlin'
-	marker_berlin.on('click', function(){
-		window.location = (this.url);
-	})
+		marker{{ forloop.counter0 }}.url = '/workflow/siteprofile_update/{{ site.id }}/';
+		marker{{ forloop.counter0 }}.on('click', function(){
+			window.location.pathname = (this.url);
+		});
 
-	// for each site we create a marker, add it to the map and a list
-	// {% for site in get_site_profile %}
-	// 	let marker{{ forloop.counter0 }} = L.marker([Number('{{site.latitude}}'), Number('{{site.longitude}}')], {
-	// 			draggable:false
-	// 	});
-	// 	marker{{ forloop.counter0 }}.url = 'www.google.com'
-	// 	marker{{ forloop.counter0 }}.addTo(map);
-	// 	marker{{ forloop.counter0 }}.on('click', function(){
-	// 		window.location = (this.url);
-	// 	});
-	// 	locations.push(marker{{ forloop.counter0 }})
-	// {% endfor %}
+		marker{{ forloop.counter0 }}.addTo(map);
+		locations.push(marker{{ forloop.counter0 }})
+	{% endfor %}
 
 	locations = [...locations];
+
+	// we use the list of site markers to autozoom the map
+	// (featureGroup leaflet.js)
 
 	// this check will catch empty lists that cause the following function
 	// to break the rendering of the map
 	if (locations !== undefined || locations.length != 0) {
-		// we use the list of site markers to autozoom the map
 		let group = new L.featureGroup(
 			locations
 		);

--- a/templates/workflow/site_profile_map.html
+++ b/templates/workflow/site_profile_map.html
@@ -136,50 +136,62 @@
 </div>
 
 <script>
-  function initMap() {
-  	// The map, centered at Uluru
-  	var map = new google.maps.Map(document.getElementById('map'), {
-  		zoom: 3,
-        center: locations[0] ? locations[0] : { lat: 0, lng: 0 }
-  	});
+	let map = L.map('map').setView([-1.2921, 36.8219], 13);
+	let my_divicon = L.divIcon({
+			className: 'arrow_box'
+	});
 
-  	// Create an array of alphabetical characters used to label the markers.
-  	var labels = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+	L.tileLayer(
+		'https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png', {
+			'attribution': 'Map tiles by Carto, under CC BY 3.0. Data by OpenStreetMap, under ODbL.'
+		}
+	).addTo(map);
 
-  	// Add some markers to the map.
-  	// Note: The code uses the JavaScript Array.prototype.map() method to
-  	// create an array of markers based on a given "locations" array.
-  	// The map() method here has nothing to do with the Google Maps API.
-  	var markers = locations.map(function(location, i) {
-  		return new google.maps.Marker({
-  			position: location,
-  			label: labels[i % labels.length],
-  		});
-  	});
+	let locations = [];
 
-  	// Add a marker clusterer to manage the markers.
-  	var markerCluster = new MarkerClusterer(map, markers, {
-  		imagePath:
-  			'https://developers.google.com/maps/documentation/javascript/examples/markerclusterer/m',
-  	});
-     }
-        var locations = [];
-        {% for site in get_site_profile %}
-         locations.push({lat: Number('{{site.latitude}}'), lng: Number('{{site.longitude}}')})
-        {% endfor %}
+	let marker_nairobi = L.marker([Number('-1.2921'), Number('36.8219')], {
+		draggable:false
+	});
+	marker_nairobi.addTo(map);
+	locations.push(marker_nairobi);
+	marker_nairobi.url = 'https://en.wikipedia.org/wiki/Nairobi'
+	marker_nairobi.on('click', function(){
+		window.location = (this.url);
+	})
 
-         locations = [...locations];
+	let marker_berlin = L.marker([Number('52.5200'), Number('13.4050')], {
+		draggable:false
+	});
+	marker_berlin.addTo(map);
+	locations.push(marker_berlin);
+	marker_berlin.url = 'https://en.wikipedia.org/wiki/Berlin'
+	marker_berlin.on('click', function(){
+		window.location = (this.url);
+	})
+
+	// for each site we create a marker, add it to the map and a list
+	// {% for site in get_site_profile %}
+	// 	let marker{{ forloop.counter0 }} = L.marker([Number('{{site.latitude}}'), Number('{{site.longitude}}')], {
+	// 			draggable:false
+	// 	});
+	// 	marker{{ forloop.counter0 }}.url = 'www.google.com'
+	// 	marker{{ forloop.counter0 }}.addTo(map);
+	// 	marker{{ forloop.counter0 }}.on('click', function(){
+	// 		window.location = (this.url);
+	// 	});
+	// 	locations.push(marker{{ forloop.counter0 }})
+	// {% endfor %}
+
+	locations = [...locations];
+
+	// this check will catch empty lists that cause the following function
+	// to break the rendering of the map
+	if (locations !== undefined || locations.length != 0) {
+		// we use the list of site markers to autozoom the map
+		let group = new L.featureGroup(
+			locations
+		);
+		map.fitBounds(group.getBounds());
+	}
 </script>
-<!--Load the API from the specified URL
-* The async attribute allows the browser to render the page while the API loads
-* The key parameter will contain your own API key (which is not needed for this tutorial)
-* The callback parameter executes the initMap() function
--->
-<script src="https://developers.google.com/maps/documentation/javascript/examples/markerclusterer/markerclusterer.js"></script>
-<script
-  async
-  defer
-  src="https://maps.googleapis.com/maps/api/js?key={{map_api_key}}&callback=initMap"
-></script>
 {% endblock %}
-


### PR DESCRIPTION
## What is the Purpose?
To replace the map shown on the siteprofile map view under the workflows section with an OSM map rendered by leaflet.js

Requirements:
- display all sites on the map
- autozoom to correct level such that all sites are visible
- each site should link to its own page for editing

## What was the approach?
Repurpose django template loop used by Google maps implementation (over the get_site_profile variable)
Research Leaflet.js autozoom: https://stackoverflow.com/questions/16845614/zoom-to-fit-all-markers-in-mapbox-or-leaflet
Research Leaflet.js links: https://github.com/Leaflet/Leaflet.markercluster/issues/486
Replace JS code in site_profile_map.html template accordingly

## Are there any concerns to addressed further before or after merging this PR?
None, the map was also already responsive but maybe Ivy should take a look just to make sure its up to scratch? (I did not need to write any CSS for this task, the map was pre-styled)

## Mentions?
@andrewtpham @IvyMMutiso @odenypeter 

## Issue(s) affected?
ACT-455
