### PR TITLE
ACT-342: Add modal for adding collected data

### DIFF
--- a/indicators/urls.py
+++ b/indicators/urls.py
@@ -6,12 +6,13 @@ from .views import (
     IndicatorList, add_indicator, indicator_create, IndicatorCreate,
     IndicatorUpdate, IndicatorDelete, PeriodicTargetDeleteView,
     PeriodicTargetView, CollectedDataReportData, CollectedDataCreate, CollectedDataDelete,
-    CollectedDataList, CollectedDataUpdate, collecteddata_import, indicator_report,
+    CollectedDataList, CollectedDataUpdate, CollectedDataAdd, collecteddata_import, indicator_report,
     TVAReport, TVAPrint, DisaggregationReport, DisaggregationPrint, IndicatorReport,
     program_indicator_report, indicator_data_report, IndicatorExport, service_json,
     collected_data_json, program_indicators_json, IndicatorReportData, IndicatorDataExport,
-    objectives_list, objectives_tree, ObjectiveUpdateView, objective_delete,LevelListView, 
-    LevelCreateView, DisaggregationTypeDeleteView, DisaggregationLabelDeleteView, LevelUpdateView
+    objectives_list, objectives_tree, ObjectiveUpdateView, objective_delete, LevelListView, 
+    LevelCreateView, DisaggregationTypeDeleteView, DisaggregationLabelDeleteView, LevelUpdateView,
+    IndicatorTarget,
 )
 
 urlpatterns = [
@@ -47,6 +48,8 @@ urlpatterns = [
          CollectedDataList.as_view(), name='collecteddata_list'),
     path('collecteddata_add/<program>/<indicator>/',
          CollectedDataCreate.as_view(), name='collecteddata_add'),
+    path('collecteddata/add',
+         CollectedDataAdd.as_view(), name='add-collected-data'),
     path('collecteddata_import/', collecteddata_import,
          name='collecteddata_import'),
     path('collecteddata_update/<int:pk>/',
@@ -102,6 +105,8 @@ urlpatterns = [
          CollectedDataReportData.as_view(), name='collecteddata_report_data'),
     path('collecteddata_report_data/<program>/<indicator>)/<type>)/export/',
          IndicatorDataExport.as_view(), name='collecteddata_report_data'),
+    path('get_target/<int:indicator_id>/', IndicatorTarget.as_view(),
+         name='indicator-targets'),
 
     # objectives
     path('objectives', objectives_list, name='objectives'),

--- a/indicators/views.py
+++ b/indicators/views.py
@@ -24,6 +24,7 @@ from django.db.models import Count, Sum, Min, Q
 from django.views.generic.edit import CreateView, UpdateView, DeleteView
 from django.views.generic.list import ListView
 from django.views.generic.detail import View
+from django.views.generic import View as GView
 from django.views.generic import TemplateView
 from django.utils.decorators import method_decorator
 from django.utils import timezone
@@ -38,6 +39,7 @@ from django_tables2 import RequestConfig
 
 from workflow.models import (
     Program, SiteProfile, Country, Sector, ActivitySites, FormGuidance,
+    Documentation
 )
 from workflow.mixins import AjaxableResponseMixin
 from workflow.admin import CountryResource
@@ -155,6 +157,8 @@ class IndicatorList(ListView):
         get_indicators = Indicator.objects.distinct().filter(
             program__organization=organization)
         get_indicator_types = IndicatorType.objects.all()
+        get_documentation = Documentation.objects.all()
+        get_periodic_target = PeriodicTarget.objects.order_by('customsort', 'create_date', 'period')
 
         program_id = int(self.kwargs['program'])
         indicator_id = int(self.kwargs['indicator'])
@@ -181,11 +185,24 @@ class IndicatorList(ListView):
             'get_programs': get_programs,
             'get_indicators': get_indicators,
             'get_indicator_types': get_indicator_types,
+            'get_periodic_target': get_periodic_target,
+            'get_documentation': get_documentation,
             'program_id': program_id,
             'indicator_id': indicator_id,
             'type_id': type_id,
             'programs': programs,
             'active': ['indicators']})
+
+
+class IndicatorTarget(GView):
+    def get(self, request, *args, **kwargs):
+        indicator_id = int(self.kwargs['indicator_id'])
+        periodic_targets = PeriodicTarget.objects.filter(indicator=indicator_id).order_by('customsort', 'create_date', 'period')
+        targets = []
+        for target in periodic_targets:
+            targets.append({"pk": target.id, "period": str(target)})
+
+        return JsonResponse({"data": targets})
 
 
 def import_indicator(service=1, deserialize=True):
@@ -468,14 +485,14 @@ class IndicatorUpdate(UpdateView):
         # create a list of dicts from disag query
         disaggregations = [
             dict(
-                disaggregation_type=item.disaggregation_type, 
-                id=item.id, 
+                disaggregation_type=item.disaggregation_type,
+                id=item.id,
                 labels=[
                     dict(label=label.label, id=label.id) for label in item.disaggregation_label.all()]
-                ) 
-                for item in get_indicator.disaggregation.all()
+                )
+            for item in get_indicator.disaggregation.all()
             ]
-        
+
         context.update({'i_name': get_indicator.name})
         context['program_id'] = get_indicator.program.all().first().id
         context['active'] = ['indicators']
@@ -591,7 +608,7 @@ class IndicatorUpdate(UpdateView):
                         )
                     else:
                         get_label = DisaggregationLabel.objects.filter(id=int(label['id'])).first()
-                        get_label.label=label['label']
+                        get_label.label = label['label']
                         get_label.save()
 
         if self.request.is_ajax():
@@ -667,6 +684,32 @@ class PeriodicTargetDeleteView(DeleteView):
         return JsonResponse({"status": "success",
                              "msg": "Periodic Target deleted successfully.",
                              "targets_sum": targets_sum})
+
+
+class CollectedDataAdd(GView):
+    """
+    Add Collected Data
+    """
+    def post(self, request):
+        data = request.POST
+
+        # print(data.get('periodic_target', ''))
+        # peridoic_target=PeriodicTarget.objects.filter(id=int(data.get('periodic_target', ''))))
+
+        collected_data = CollectedData.objects.create(
+            achieved=data.get('actual', ''),
+            targeted=data.get('target', ''),
+            date_collected=data.get('date_collected', None),
+            periodic_target=PeriodicTarget.objects.filter(id=int(data.get('periodic_target', ''))).first(),
+            indicator=Indicator.objects.filter(id=int(data.get('indicator', ''))).first(),
+            evidence=Documentation.objects.filter(id=int(data.get('documentation', None))).first(),
+            program=Program.objects.filter(id=int(data.get('program', ''))).first(),
+        )
+
+        if collected_data:
+            return JsonResponse(dict(status=201))
+        else:
+            return JsonResponse(dict(status=400))
 
 
 class CollectedDataCreate(CreateView):
@@ -966,6 +1009,7 @@ class DisaggregationLabelDeleteView(DeleteView):
 
         except Exception as e:
             return JsonResponse(dict(status=400))
+
 
 class CollectedDataDelete(DeleteView):
     """

--- a/static/js/collectdata.js
+++ b/static/js/collectdata.js
@@ -1,0 +1,160 @@
+$(document).ready(() => {
+    $('#id_evidence').select2({
+        theme: 'bootstrap'
+    });
+    $('#addCollectedDataModal').on('hidden.bs.modal', function(e){ 
+        $(".target_period").html("");
+        $('#addCollectedDataForm').trigger('reset');
+    });
+$('#id_date_collected').on('input', function () {
+    const name = $(this);
+    if (name.val()) {
+        $('#div_date_collected')
+            .removeClass('has-error')
+            .addClass('has-success');
+        $('#dateHelpBlock')
+            .removeClass('hikaya-show')
+            .addClass('hikaya-hide');
+    } else {
+        $('#div_date_collected')
+            .removeClass('has-success')
+            .addClass('has-error');
+        }
+    });
+$('#id_actual').on('input', function () {
+    const name = $(this);
+    if (name.val()) {
+        $('#div_actual_value')
+            .removeClass('has-error')
+            .addClass('has-success');
+        $('#actualHelpBlock')
+            .removeClass('hikaya-show')
+            .addClass('hikaya-hide');
+    } else {
+        $('#div_actual_value')
+            .removeClass('has-success')
+            .addClass('has-error');
+        }
+    });
+$('#id_periodic_target').on('change', function () {
+    const name = $(this);
+    if (name.val()) {
+        $('#div_periodic_target')
+            .removeClass('has-error')
+            .addClass('has-success');
+        $('#periodHelpBlock')
+            .removeClass('hikaya-show')
+            .addClass('hikaya-hide');
+    } else {
+        $('#div_periodic_target')
+            .removeClass('has-success')
+            .addClass('has-error');
+        }
+    });
+
+// show quick add modal if quick-modal to true
+const url = new URL(window.location.href);
+if (url.searchParams.get('open-modal')) {
+        $('#addCollectedDataModal').modal('show');
+    }
+})
+$(document).on("click", ".collectdata", function () {
+var indicatorId = $(this).data('indicator');
+$(".target_period").select2({
+    theme: 'bootstrap',
+    placeholder: "Select Target Period",
+    ajax: {
+        url: '/indicators/get_target/'+ indicatorId + '/',
+        dataType: 'json',
+        type: 'GET',
+        processResults: function (data) {
+            var res = data.data.map(function (item) {
+                    return {id: item.pk, text: item.period};
+            });
+            return {
+            results: res
+        };
+    }
+}
+});
+})
+var saveCollectedData = buttonId => {
+    $(`#${buttonId}`).click(e => {
+        e.preventDefault();
+        const formValue = $('#addCollectedDataForm').serializeArray();
+        const data = {"periodic_target":''}
+
+        var indicatorId = $('#id_periodic_target').attr('data-tag')
+        var programId = $('#id_periodic_target').attr('data-tag2')
+        formValue.forEach(item => {
+            data[item.name] = item.value;
+        });
+
+        data['indicator'] = indicatorId
+        data['program'] = programId
+        if (data.date_collected=='' || data.actual == '' || data.periodic_target == '') {
+            if(data.date_collected==''){    
+                $('#div_date_collected')
+                .removeClass('has-success')
+                .addClass('has-error');
+                $('#dateHelpBlock')
+                .removeClass('hikaya-hide')
+                .addClass('hikaya-show');
+            }
+            if(data.actual == ''){
+                $('#div_actual_value')
+                .removeClass('has-success')
+                .addClass('has-error');
+                $('#actualHelpBlock')
+                .removeClass('hikaya-hide')
+                .addClass('hikaya-show');
+            }
+            if(data.periodic_target == ''){
+                $('#div_periodic_target')
+                .removeClass('has-success')
+                .addClass('has-error');
+                $('#periodHelpBlock')
+                .removeClass('hikaya-hide')
+                .addClass('hikaya-show');}
+
+            toastr.error('Fill in all required fields');
+        } else {
+            $.ajax({
+                url: myURL,
+                type: 'POST',
+                data: data,
+                success: function(resp, status) {
+                    const urlWithoutQueryString = window.location.href.split('?')[0];
+                    if (buttonId === 'addCollectedDataAndNew') {
+                        // notify success
+                        toastr.success('Collected Data was added sucessfully, You can now add another one');
+                        $('#id_actual').val("");
+                        $('#div_actual_value').removeClass('has-success')
+                        $('#id_date_collected').val("");
+                        $('#div_date_collected').removeClass('has-success')
+                        $('#div_periodic_target').removeClass('has-success')
+                    } else {
+                         // notify success
+                        toastr.success('Collected Data was added sucessfully');
+                        //close modal
+                        $('#addCollectedDataModal').modal('hide');
+                        // reset form
+                        $('#addCollectedDataForm').trigger('reset');
+                        setTimeout(() => {
+                            window.location.replace(urlWithoutQueryString);
+                        }, 2000);
+                    }
+                },
+                error: function(xhr, status, error) {
+                    toastr.error(error, 'Failed');
+                },
+            });
+            
+        }            
+    });
+};
+
+$(() => {
+    saveCollectedData('addCollectedData');
+    saveCollectedData('addCollectedDataAndNew');
+});

--- a/templates/indicators/add_collecteddata_modal.html
+++ b/templates/indicators/add_collecteddata_modal.html
@@ -1,0 +1,103 @@
+{% block content %}
+<script type='text/javascript' > 
+    var myURL = "{% url 'add-collected-data' %}"; 
+  </script>
+<script type="text/javascript" src="{{ STATIC_URL }}js/collectdata.js"></script>
+
+<div class="modal fade" id="addCollectedDataModal" tabindex="-1" role="dialog">
+    <div class="modal-dialog modal-md" role="form">
+        <div class="modal-content">
+            <form id="addCollectedDataForm">
+                {% csrf_token %}
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                    <h4 class="modal-title">Add Collected Data</h4>
+                </div>
+                <div class="modal-body">
+                    <div>
+                        <div class="row">
+                            <div class="col-md-6 col-sm-6">
+                                <div class="form-group" id="div_periodic_target">
+                                    <label for="id_periodic_target">Periodic Target*</label>
+                                    <select name="periodic_target" id="id_periodic_target" class="form-control target_period" data-tag="" data-tag2="">
+                                    </select>
+                                    <span id="periodHelpBlock" class="help-block hikaya-hide">Target period is required</span>
+                                </div>
+                            </div>
+                            <div class="col-md-6 col-sm-6">
+                                <div class="form-group" id="div_date_collected">
+                                    <label for="id_date_collected">Date Collected*</label>
+                                    <input type="date" id="id_date_collected" name="date_collected" class="form-control">
+                                    <span id="dateHelpBlock" class="help-block hikaya-hide">Collection date is required</span>
+                                </div>
+                            </div>
+                        </div>
+
+                        <br>
+
+                        <div class="row">
+                            <div class="col-md-6 col-sm-6">
+                                <div class="form-group">
+                                    <label for="id_target">Target*</label>
+                                    <input type="number" id="id_target" name="target" class="form-control"
+                                        value="" readonly>
+                                </div>
+                            </div>
+
+                            <div class="col-md-6 col-sm-6">
+                                <div class="form-group" id="div_actual_value">
+                                    <label for="id_actual">Actual*</label>
+                                    <input type="number" name="actual" id="id_actual" class="form-control" required>
+                                    <span id="actualHelpBlock" class="help-block hikaya-hide">Actual value is required</span>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="row">
+                            <div class="col-md-8 col">
+                                <div class="form-group" id="div_evidence">
+                                    <label for="id_evidence">Evidence</label>
+                                    <select name="documentation" id="id_evidence" class="form-control">
+                                        <option value=""></option>
+                                        {% for document in get_documentation %} {% if document.name %}
+                                        <option value="{{ document.id }}">{{ document.name }}</option>
+                                        {% endif %} {% endfor %}
+                                    </select>
+                                    <span id="evidenceHelpBlock" class="help-block hikaya-hide">Evidence is required</span>
+                                </div>
+                            </div>
+                        </div>
+
+                        <br>
+
+                        <div class="row mb-15">
+                            <div class="col-md-8 col-sm-12">
+                                <div class="disaggregation">
+                                    <h4>Disaggregation</h4>
+                                    <button type="button" class="btn btn-default btn-sm disabled"
+                                        id="add_disaggregation">Add
+                                        Disaggregation</button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-close" data-dismiss="modal">
+                        Close
+                    </button>
+                    <button id="addCollectedDataAndNew" type="button" class="btn btn-outline-success">
+                        Save &amp; New
+                    </button>
+                    <button id="addCollectedData" type="button" class="btn btn-success">
+                        Save
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+{% endblock content %}

--- a/templates/indicators/indicator_list.html
+++ b/templates/indicators/indicator_list.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %} {% block content %}
 {% include './add_indicator_modal.html' %}
+{% include './add_collecteddata_modal.html' %}
 
 <script>
   $(document).ready(() => {
@@ -35,6 +36,15 @@
         }
     })
   })
+
+  $(document).on("click", ".collectdata", function () {
+    var setTarget = $(this).data('settarget');
+    var indicatorId = $(this).data('indicator');
+    var programId = $(this).data('program')
+    $("#id_target").val(setTarget);
+    $("#id_periodic_target").attr('data-tag',indicatorId );
+    $("#id_periodic_target").attr('data-tag2',programId );
+})
 </script>
 
 <div class="container">


### PR DESCRIPTION
## What is the Purpose?
- [x] Add quick action (modal) to add actuals through all indicators for a specific periodic target.
- [x] Add Save & New button to modal for adding newly collected data.
- [x] Add validation for the collected data details edit page.

## What was the approach?
- Added quick action modal for adding actuals for specific indicators. The form also has field validations for required fields and `save and new` button that saves and resets the form for data to be added again for the same indicator.

## Are there any concerns to addressed further before or after merging this PR?
None

## Mentions?
@odenypeter @andrewtpham 

## Issue(s) affected?
[ACT-342](https://hikaya.atlassian.net/browse/ACT-342)
[ACT-343](https://hikaya.atlassian.net/browse/ACT-343)
[ACT-468](https://hikaya.atlassian.net/browse/ACT-468)