### PR TITLE
Fix 'add collected data' button to open modal instead of separate page

### DIFF
--- a/static/js/collectdata.js
+++ b/static/js/collectdata.js
@@ -92,6 +92,11 @@ var saveCollectedData = buttonId => {
 
         data['indicator'] = indicatorId
         data['program'] = programId
+        
+        if (data.documentation == ''){
+            data['documentation'] = 0
+        }
+
         if (data.date_collected=='' || data.actual == '' || data.periodic_target == '') {
             if(data.date_collected==''){    
                 $('#div_date_collected')

--- a/templates/indicators/collected_data_table.html
+++ b/templates/indicators/collected_data_table.html
@@ -174,8 +174,8 @@
         {% endif %}
     </table>
     <div class="text-right">
-        <a href="/indicators/collecteddata_add/{{ program_id }}/{{ indicator.id }}" role="button"
-           class="btn btn-sm btn-success">Add Collected Data</a>
+        <button data-toggle="modal" data-settarget="{{indicator.lop_target}}" data-target="#addCollectedDataModal" data-program="{{program_id}}" data-indicator="{{indicator.id}}" role="button"
+        class="btn btn-sm btn-success collectdata">Add Collected Data</button>
     </div>
 {% else %}
     <table class="table table-condensed table-bordered" id="">
@@ -191,7 +191,7 @@
         </tr>
     </table>
     <div class="text-right">
-        <a href="/indicators/collecteddata_add/{{ program_id }}/{{ indicator.id }}" role="button"
-           class="btn btn-sm btn-success">Add Collected Data</a>
+            <button data-toggle="modal" data-settarget="{{indicator.lop_target}}" data-target="#addCollectedDataModal" data-program="{{program_id}}" data-indicator="{{indicator.id}}" role="button"
+              class="btn btn-sm btn-success collectdata">Add Collected Data</button>
     </div>
 {% endif %}


### PR DESCRIPTION
## What is the Purpose?
Update `add collected data` button to open a modal instead of opening a different page to enter the collected data.

## What was the approach?
Remove existing links and replace them with `<button>` and relevant attributes to open the modal correctly

## Are there any concerns to addressed further before or after merging this PR?
None

## Mentions?
@odenypeter 

## Issue(s) affected?
ACT-342
