### PR TITLE
fixed hikaya 404 link - now linking to hikaya homepage

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -67,7 +67,7 @@
 
   <!--- Django Tables2 css -->
   <link rel="stylesheet" href="{% static 'django_tables2/themes/paleblue/css/screen.css' %}" />
- 
+
   <!-- Hosted Leaflet CSS -->
   <!-- <link rel="stylesheet" href="{% static 'css/leaflet.css' %}" /> -->
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.6.0/dist/leaflet.css"
@@ -91,10 +91,10 @@
   <script src="https://unpkg.com/leaflet@1.6.0/dist/leaflet.js"
    integrity="sha512-gZwIG9x3wUXg2hdXF6+rVkLF/0Vi9U8D2Ntg4Ga5I5BZpVkVxlJWbSQtXPSiUTtC0TjtGOmxa1AJPuV0CPthew=="
    crossorigin=""></script>
-   
+
    <!-- Vue.js scripts -->
    <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
-   <script src="https://unpkg.com/axios/dist/axios.min.js"></script> 
+   <script src="https://unpkg.com/axios/dist/axios.min.js"></script>
    <script src="https://cdn.jsdelivr.net/npm/vee-validate@2.0.0/dist/vee-validate.js"></script>
   <script src="https://unpkg.com/vuejs-paginate@latest"></script>
    <!-- end of Vue.js scripts -->
@@ -392,7 +392,7 @@
       {% if "links.html"|template_exists %} {% include "links.html" %}
       {% else %}
       <div class="column col-xs-16 text-right">
-        <a href="http://www.hikaya.io" class="text-muted"><b>Hikaya</b></a> |
+        <a href="https://hikaya.io" class="text-muted"><b>Hikaya</b></a> |
         <a href="https://help.hikaya.io" class="text-muted"><b>Documentation</b></a>
         |
         <a href="https://github.com/hikaya-io/Activity-CE/blob/master/LICENSE" class="text-muted"><b>License</b></a>


### PR DESCRIPTION
## What is the Purpose?
I fixed the 'Hikaya' footer link to lead to the Hikaya homepage

## What was the approach?
I simply saw that the link went to a 404 so I swapped the link with the correct one.

## Are there any concerns to addressed further before or after merging this PR?
Nope, no concerns at all. Simple HTML change in base.html

## Issue(s) affected?
This address half of #295 
