### PR TITLE
Bump django version to 2.2.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ cssselect2==0.2.1
 defusedxml==0.6.0
 dicttoxml==1.7.4
 diff-match-patch==20181111
-django==2.2.10
+django==2.2.12
 django-ckeditor==5.7.0
 django-crispy-forms==1.7.2
 django-debug-toolbar==1.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ cssselect2==0.2.1
 defusedxml==0.6.0
 dicttoxml==1.7.4
 diff-match-patch==20181111
-django==2.2.12
+django==2.2.11
 django-ckeditor==5.7.0
 django-crispy-forms==1.7.2
 django-debug-toolbar==1.11


### PR DESCRIPTION
To fix Potential SQL injection via tolerance parameter in GIS functions and aggregates on Oracle https://docs.djangoproject.com/en/3.0/releases/2.2.11/ 