### PR TITLE
ACT-680[WIP]: Add config for coverage provision by codecov

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+
+[run]
+omit =
+    */site-packages/*
+    */distutils/*
+    tests/*

--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,2 +1,0 @@
-service_name: travis-pro
-repo_token: GI8udXrAacDaAoYnfIBbFerzyVtGT11yO

--- a/.github/workflows/activity_ci_cd.yml
+++ b/.github/workflows/activity_ci_cd.yml
@@ -5,7 +5,6 @@ on:
     branches: 
       - dev
       - master
-      - ACT-609
   pull_request:
     branches: 
       - dev
@@ -34,14 +33,16 @@ jobs:
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Run Tests
+      env: 
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       run: |
         pipenv install
         source $(python3 -m pipenv --venv)/bin/activate
-        coverage run --source=activity manage.py test
+        coverage run manage.py test
         echo "++++++++ Show test coverage report +++++++"
         coverage report
-        coveralls
-
+        echo "----------- Upload test coverage ---------"
+        bash <(curl -s https://codecov.io/bash)
 
   Infrastructure:
     runs-on: ubuntu-latest 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <br/>
 <p align="center">
   <a href='https://travis-ci.org/hikaya-io/activity.svg?branch=dev'><img src='https://travis-ci.org/hikaya-io/activity.svg?branch=dev' alt='Travis Status' /></a>
-  <a href='https://coveralls.io/github/hikaya-io/activity?branch=dev'><img src='https://coveralls.io/repos/github/hikaya-io/activity/badge.svg?branch=dev' alt='Coverage Status' /></a>
+  <a href="https://codecov.io/gh/hikaya-io/activity"><img src="https://codecov.io/gh/hikaya-io/activity/branch/dev/graph/badge.svg" alt="Codecov badge" /></a>
   <a href='https://github.com/hikaya-io/activity/workflows/Activity/badge.svg'><img src='https://github.com/hikaya-io/activity/workflows/Activity/badge.svg' alt='GH Actions Status' /></a>
 </p>
 

--- a/ci-scripts/run_tests.sh
+++ b/ci-scripts/run_tests.sh
@@ -32,10 +32,15 @@ run_linter() {
 #@--- run tests --- @#
 run_tests() {
     echo "++++++++++++++++ Run tests ++++++++++++++++"
-    coverage run --source=activity manage.py test
+    coverage run  manage.py test
     coverage report
-    coveralls
 }
+
+#@--- function to report coverage ---@#
+report_coverage() {
+    bash <(curl -s https://codecov.io/bash) 
+}
+
 
 #@--- Main function ---@#
 main() {
@@ -51,6 +56,9 @@ main() {
 
     #@--- Run tests ---@#
     run_tests
+
+    #@--- Report Coverage ---@#
+    report_coverage
 }
 
 #@--- Run main function ---@#


### PR DESCRIPTION
## What is the Purpose?
Use codecov to report on code coverage

## What was the approach?
Add config to CI tools to send code coverage to codecov rather than coveralls. Fixes the coverage command to point to all project files omitting virtualenv files

## Are there any concerns to addressed further before or after merging this PR?
Glitch with Travis not getting notifications on PR events or Push events. Need to test Codecov functionality with travis before the merge. It works well on GitHub actions

## Mentions?
Mention persons you'd like to review this PR

## Issue(s) affected?
List of issues addressed by this PR. 
