### PR TITLE
ACT-683: Edit and Delete target periods Vue modal

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -163,7 +163,7 @@
                 "sha256:89c2007ca4fa5b351a51a279eccff298520783b713bf28efb89dfb81c80ea49b"
             ],
             "index": "pypi",
-            "version": "==2.2.7"
+            "version": "==2.2.10"
         },
         "django-appconf": {
             "hashes": [

--- a/indicators/views.py
+++ b/indicators/views.py
@@ -168,7 +168,8 @@ class IndicatorList(ListView):
             program__organization=organization)
         get_indicator_types = IndicatorType.objects.all()
         get_documentation = Documentation.objects.all()
-        get_periodic_target = PeriodicTarget.objects.order_by('customsort', 'create_date', 'period')
+        get_periodic_target = PeriodicTarget.objects.distinct().filter(
+            indicator__program__organization=organization)
 
         program_id = int(self.kwargs['program'])
         indicator_id = int(self.kwargs['indicator'])
@@ -2237,3 +2238,7 @@ class PeriodicTargetCreateView(generics.ListCreateAPIView, generics.RetrieveUpda
             indicator.update(**indicator_data)
             return Response(serialized.data, status=status.HTTP_201_CREATED)
         return Response(serialized._errors, status=status.HTTP_400_BAD_REQUEST)
+
+    def get_queryset(self):
+        organization = self.request.user.activity_user.organization
+        return PeriodicTarget.objects.filter(indicator__program__organization=organization)

--- a/static/vue.js/collected_data_table.js
+++ b/static/vue.js/collected_data_table.js
@@ -81,7 +81,6 @@ $(document).ready(() => {
               this.show_disaggregations= false
 
               if (item) {
-                console.log(item)
                 this.isEdit = true;
                 this.modalHeader = `Edit Result`;
                 this.currentResult = item;

--- a/static/vue.js/indicators/target_period.js
+++ b/static/vue.js/indicators/target_period.js
@@ -117,7 +117,7 @@ new Vue({
         generateYearlyTargets: function(periodStart){
             for (let i = 1; i <= this.number_of_target_periods; i++) {
                 const period = `Year ${i}`
-                const id = `${i}`
+                const pk = `${i}`
                 let periodEnds = moment(periodStart);
                 let start_date = moment(periodStart)
                             .startOf("month")
@@ -127,8 +127,10 @@ new Vue({
                             .endOf("month")
                             .format("MMM DD, YYYY");
 
-
-                this.targets = [...this.targets, { id, start_date, end_date, period}];
+                console.log(pk)
+                console.log(this.targets)
+                this.targets = [...this.targets, { pk, start_date, end_date, period}];
+                console.log(this.targets)
 
                 periodStart = moment(periodEnds).add(12, "months");
             }
@@ -138,7 +140,7 @@ new Vue({
         generateSemiAnnualTargets: function(periodStart){
             for (let i = 1; i <= this.number_of_target_periods; i++) {
                 const period = `SemiAnnual ${i}`
-                const id = `${i}`
+                const pk = `${i}`
                 let periodEnds = moment(periodStart);
                 let start_date = moment(periodStart)
                             .startOf("month")
@@ -148,7 +150,7 @@ new Vue({
                             .endOf("month")
                             .format("MMM DD, YYYY");
 
-                this.targets = [...this.targets, { id, start_date, end_date, period}];
+                this.targets = [...this.targets, { pk, start_date, end_date, period}];
 
                 periodStart = moment(periodEnds).add(6, "months");
             }
@@ -158,7 +160,7 @@ new Vue({
         generateTriAnnualTargets: function(periodStart){
             for (let i = 1; i <= this.number_of_target_periods; i++) {
                 const period = `Triannual ${i}`
-                const id = `${i}`
+                const pk = `${i}`
                 let periodEnds = moment(periodStart);
                 let start_date = moment(periodStart)
                             .startOf("month")
@@ -169,7 +171,7 @@ new Vue({
                             .format("MMM DD, YYYY");
 
 
-                this.targets = [...this.targets, { id, start_date, end_date, period}];
+                this.targets = [...this.targets, { pk, start_date, end_date, period}];
 
                 periodStart = moment(periodEnds).add(4, "months");
             }
@@ -179,7 +181,7 @@ new Vue({
         generateQuarterlyTargets: function(periodStart){
             for (let i = 1; i <= this.number_of_target_periods; i++) {
                 const period = `Quarter ${i}`
-                const id = `${i}`
+                const pk = `${i}`
                 let periodEnds = moment(periodStart)
                 let start_date = moment(periodStart)
                             .startOf("month")
@@ -190,7 +192,7 @@ new Vue({
                             .format("MMM DD, YYYY");
 
 
-                this.targets = [...this.targets, { id, start_date, end_date, period}];
+                this.targets = [...this.targets, { pk, start_date, end_date, period}];
 
                 periodStart = moment(periodEnds).add(3, "months");
             }
@@ -199,7 +201,7 @@ new Vue({
         generateMonthlyTargets: function(periodStart){
             for (let i = 1; i <= this.number_of_target_periods; i++) {
                 const period = `Month ${i}`
-                const id = `${i}`
+                const pk = `${i}`
                 let periodEnds = moment(periodStart)
                 let start_date = moment(periodStart)
                             .startOf("month")
@@ -209,7 +211,7 @@ new Vue({
                             .endOf("month")
                             .format("MMM DD, YYYY");
 
-                this.targets = [...this.targets, { id, start_date, end_date, period}];
+                this.targets = [...this.targets, { pk, start_date, end_date, period}];
 
                 periodStart = moment(periodEnds).add(1, "months");
             } 
@@ -230,43 +232,68 @@ new Vue({
             this.showTable = false
             this.disabledClass = false
             this.isEdit = false
-            this.modalHeader = "Add target periods"
+            this.modalHeader = "Add Target Periods"
 
             this.target_period_data.forEach(target =>{
                 if(target.indicator.indicator_id == this.indicator_id){
-                    console.log(target)
                     this.isEdit = true
                     this.overall_target = target.indicator.indicator_lop
+                    this.sum = target.indicator.indicator_lop
                     this.baseline= target.indicator.baseline
                     this.rationale= target.indicator.rationale
-                    const id = target.id
+                    const pk = target.id
                     const start_date = target.start_date
                     const end_date = target.end_date
                     const period = target.period
                     const target_value = target.target
-                    this.targets = [...this.targets, {id, start_date, end_date, period, target_value}]
+                    this.targets = [...this.targets, {pk, start_date, end_date, period, target_value}]
                     
                 }
             })
             if(this.isEdit){
                 this.targets.reverse()
-                this.modalHeader = 'Edit target period'
+                this.modalHeader = 'Edit Target Periods'
                 this.targets.forEach(target => {
-                    this.target_value[target.id] = target.target_value
+                    this.target_value[target.pk] = target.target_value
                 })
                 this.showTable = true
+                this.show= true 
+                this.disabledClass = true
+                this.number_of_target_periods = this.targets.length
+                this.target_frequency_start = moment(this.targets[0].start_date).format("YYYY-MM")
+                if (this.targets[0].period.includes('Year')){
+                    this.target_frequency = "3"
+                }else if(this.targets[0].period.includes('Semi')){
+                    this.target_frequency = "4"
+                }else if(this.targets[0].period.includes('Tri')){
+                    this.target_frequency = "5"
+                }else if(this.targets[0].period.includes('Month')){
+                    this.target_frequency = "7"
+                }else if(this.targets[0].period.includes('Quarter')){
+                    this.target_frequency = "6"
+                }
+
+                
             }
    
             this.showModal = !this.showModal
 
         },
+        toggleDeleteModal: function () {
+            this.showDeleteModal = !this.showDeleteModal;
+            this.modalHeader = 'Confirm delete';
+          },
 
         processForm: function() {
             this.$validator.validateAll().then(target => {
                 if (target) {
                     if (this.targets.length > 0){
-                        if (this.sum === parseInt(this.overall_target)){
-                            this.postTarget()
+                        if (parseInt(this.sum) === parseInt(this.overall_target)){
+                            if(this.isEdit){
+                                this.updateTargets()
+                            }else{
+                                this.postTarget()
+                            }
                         }else{
                             toastr.error('The sum of target values must be equal to overall target');
                         }
@@ -278,13 +305,20 @@ new Vue({
         },
 
         async postTarget() {
-            this.target_value.forEach((item, index) => {
-                this.targets.forEach((target =>{
-                    if (index === parseInt(target.id)){
-                        target["target"] = item
-                    }
-                }))
-            })
+            for (var key in this.target_value) {
+                if (this.target_value.hasOwnProperty(key)) {
+                    this.targets.forEach((target =>{
+                        console.log(typeof(key))
+                        console.log(target)
+                        if (parseInt(key) === parseInt(target.pk)){
+                            console.log("sound")
+                            target["target"] = this.target_value[key]
+                        }
+                    }))
+                     
+                }
+            }
+            
             const id = this.indicator_id
             this.targets = this.targets.map(function (obj) {
                 obj['indicator_id'] = obj['id'];
@@ -311,6 +345,10 @@ new Vue({
 
                 if (response){
                     this.toggleTargetModal();
+                    this.target_period_data = []
+                    response.data.data.forEach(target => {
+                        this.target_period_data.push(target)
+                    })
                     toastr.success('Target periods were saved successfully');
                     this.$validator.reset();
                 }
@@ -319,6 +357,87 @@ new Vue({
             }
 
         },
+
+        async updateTargets(){
+            for (var key in this.target_value) {
+                if (this.target_value.hasOwnProperty(key)) {
+                    this.targets.forEach((target =>{
+                        console.log(typeof(key))
+                        console.log(target)
+                        if (parseInt(key) === parseInt(target.pk)){
+                            console.log("sound")
+                            target["target"] = this.target_value[key]
+                        }
+                    }))
+                     
+                }
+            }
+            
+            const id = this.indicator_id
+            this.targets = this.targets.map(function (obj) {
+                obj['indicator_id'] = obj['id'];
+                obj['start_date'] = moment(obj['start_date']).format("YYYY-MM-DD")
+                obj['end_date'] = moment(obj['end_date']).format("YYYY-MM-DD")
+                delete obj['id'];
+                obj['indicator_id'] = id
+                return obj;
+            });
+
+            const data = {
+                indicator_id : id,
+                indicator_LOP: this.overall_target,
+                indicator_baseline: this.baseline,
+                rationale : this.rationale,
+                periodic_targets: this.targets
+            }
+
+            try {
+                const response = await this.makeRequest(
+                    'PATCH',
+                    `/indicators/periodic_target/`,
+                    {data}
+                  );
+
+                if (response){
+                    this.toggleTargetModal();
+                    this.target_period_data = []
+                    toastr.success('Target periods were updated successfully');
+                    response.data.data.forEach(target => {
+                        this.target_period_data.push(target)
+                    })
+                    this.$validator.reset();
+                }
+            } catch (error) {
+                toastr.error('There was a problems updating your data.');
+            }
+
+        },
+
+
+        async deleteTargets() {
+            const id = this.indicator_id
+            try {
+              const response = await this.makeRequest(
+                'DELETE',
+                `/indicators/periodic_target/`,
+                {id}
+              );
+              if (response) {
+                this.target_period_data = []
+                toastr.success('Target periods were successfully deleted.');
+                response.data.data.forEach(target => {
+                    this.target_period_data.push(target)
+                })
+                this.showDeleteModal = !this.showDeleteModal;
+                this.toggleTargetModal();
+              } else {
+                this.modalHeader = 'Add Target Periods';
+                toastr.error('There was a problem deleting the targets.');
+              }
+            } catch (error) {
+              toastr.error('There was a server error');
+            }
+          },
 
     },
     computed: {

--- a/templates/indicators/forms/target_period_form_footer.html
+++ b/templates/indicators/forms/target_period_form_footer.html
@@ -11,5 +11,12 @@
         class="btn btn-success"
         :disabled="errors.any() || !isFormValid"
         @click=processForm()
-    >Save</button>  
+    >Save</button>
+    <button
+        v-if="isEdit"
+        type="button"
+        class="btn btn-success"
+        :disabled="errors.any() || !isFormValid"
+        @click=processForm()
+    >Update</button>  
 </div>

--- a/templates/indicators/forms/target_period_modal.html
+++ b/templates/indicators/forms/target_period_modal.html
@@ -151,7 +151,7 @@
             <div v-show="showTable" class="col-md-12" id="id_targets">
                 <table id="targetsTable" class="table table-hover">
                     <tbody>
-                        <tr v-for=" target in targets" :key="target.id">
+                        <tr v-for="target in targets" :key="target.id">
                             <th>[[target.period]]<br><small>[[target.start_date]] - [[target.end_date]]</small></th>
                             <td>
                                 <input 

--- a/templates/indicators/forms/target_period_modal.html
+++ b/templates/indicators/forms/target_period_modal.html
@@ -64,7 +64,8 @@
                           }"
                         style="width:200px;"
                         @change=showFields()
-                        v-model="target_frequency" 
+                        v-model="target_frequency"
+                        :readonly= "disabledClass" 
                         v-validate="'required'">
                         <option value="" disabled>Select target period</option>
                         <option v-for="frequency in frequencies" :value="frequency.id">
@@ -127,7 +128,19 @@
               <div class="row" id="id_control_btns">
                 <div class="col-md-12">
                   <div class="form-group text-right" v-if="show">
-                    <button
+                    <span v-if="isEdit">
+                      <button
+                      type="button"
+                      class="btn btn-link btn-link-warning"
+                      id="clearTargets"
+                      :disabled= "!disabledClass"
+                      @click= toggleDeleteModal()
+                    >
+                      Remove all targets
+                    </button>
+                  </span>
+                    <span v-else>
+                      <button
                       type="button"
                       class="btn btn-link btn-link-warning"
                       id="clearTargets"
@@ -136,6 +149,8 @@
                     >
                       Remove all targets
                     </button>
+                  </span>
+                    
                     <button type="button" 
                             class="btn btn-warning"
                             id="addTargetsBtn"
@@ -161,7 +176,7 @@
                                 v-on:keyup="updateSum()"
                                 type="number" 
                                 :id="target.id"
-                                v-model= "target_value[target.id]"
+                                v-model= "target_value[target.pk]"
                                 name="target value"
                                 v-validate="'required'"/>
                                 <span v-show="errors.has('target value')" class="help is-danger">[[ errors.first('target value') ]]</span>

--- a/templates/indicators/indicator_list.html
+++ b/templates/indicators/indicator_list.html
@@ -3,8 +3,6 @@
 {% include './collected_data_table2.html'%}
 {% include 'ui-components/vue_modal.html'%}
 
-
-
 <div id="indicators_list" class="container">
   {% block breadcrumbs %}
   <ul class="breadcrumb">
@@ -102,7 +100,7 @@
             <ul class="dropdown-menu nav">
               <li class="dropdown-header">Related</li>
               <!-- <li><a href="">Results</a></li> -->
-              <li><a @click="toggleTargetModal({{indicator.id}})">Add target periods</a></li>
+              <li><a @click="toggleTargetModal({{indicator.id}})">Target periods</a></li>
               <li><a href="/indicators/indicator_update/{{indicator.id}}/">Objectives</a></li>
               <li><a href="/indicators/indicator_update/{{indicator.id}}/">Levels</a></li>
               <li><a href="/indicators/indicator_update/{{indicator.id}}/">Sectors</a></li>

--- a/templates/indicators/indicator_list.html
+++ b/templates/indicators/indicator_list.html
@@ -100,7 +100,7 @@
             <ul class="dropdown-menu nav">
               <li class="dropdown-header">Related</li>
               <!-- <li><a href="">Results</a></li> -->
-              <li><a @click="toggleTargetModal({{indicator.id}})">Target periods</a></li>
+              <li><a @click="toggleTargetModal({{indicator.id}})" >Add/Edit target periods</a></li>
               <li><a href="/indicators/indicator_update/{{indicator.id}}/">Objectives</a></li>
               <li><a href="/indicators/indicator_update/{{indicator.id}}/">Levels</a></li>
               <li><a href="/indicators/indicator_update/{{indicator.id}}/">Sectors</a></li>
@@ -124,6 +124,25 @@
     </div>
     <div slot="footer">
       {% include 'indicators/forms/target_period_form_footer.html' %}
+    </div>
+    <h4 slot="header">[[modalHeader]]</h4>
+  </modal>
+  <modal v-if=showDeleteModal @close="showDeleteModal = false" >
+    <div slot="body">
+      <p>Are you sure you want to delete target periods? Any results added will also be deleted</p>
+    </div>
+    <div slot="footer">
+      <div class="text-right">
+        <button type="submit" class="btn btn-close" @click="showDeleteModal = false, modalHeader = 'Edit Target Modal'">
+          Cancel
+        </button>
+        <button
+          class="btn btn-danger"
+          @click=deleteTargets()
+        >
+          Delete
+        </button>
+      </div>
     </div>
     <h4 slot="header">[[modalHeader]]</h4>
   </modal>

--- a/templates/indicators/indicator_list.html
+++ b/templates/indicators/indicator_list.html
@@ -100,7 +100,7 @@
             <ul class="dropdown-menu nav">
               <li class="dropdown-header">Related</li>
               <!-- <li><a href="">Results</a></li> -->
-              <li><a @click="toggleTargetModal({{indicator.id}})" >Add/Edit target periods</a></li>
+              <li><a @click="toggleTargetModal({{indicator.id}})" >Target Periods</a></li>
               <li><a href="/indicators/indicator_update/{{indicator.id}}/">Objectives</a></li>
               <li><a href="/indicators/indicator_update/{{indicator.id}}/">Levels</a></li>
               <li><a href="/indicators/indicator_update/{{indicator.id}}/">Sectors</a></li>


### PR DESCRIPTION
## What is the Purpose?
- Finish Update and delete functionality for target periods

## What was the approach?
- Updated Django view to enable delete and update multiple target periods.
- Update modal to be dynamically created with target periods if they exist and allow users to edit them.
- Delete target periods if they existed.

## Are there any concerns to addressed further before or after merging this PR?
The create target periods' logic changed a bit. Please test the entire CRUD operation, from creating target periods to deleting them.

## Mentions?
@andrewtpham @ninetteadhikari @IvyMMutiso 

## Issue(s) affected?
ACT-683
ACT-557
ACT-722
