### PR TITLE
ACT-731: Fix error when updating indicator data

### DIFF
--- a/templates/indicators/form-sections/targets.html
+++ b/templates/indicators/form-sections/targets.html
@@ -123,7 +123,7 @@
 
   $("#indicator_data").submit(function( event ) {
     
-    if($("#id_lop_target").val()){
+    if($("#sumOfTargets").text()){
       if($("#id_lop_target").val() != $("#sumOfTargets").text()){
         toastr.error('The sum of target values must be equal to overall target');
       }else{


### PR DESCRIPTION
## What is the Purpose?
Fix the error that occurs when updating an indicator with existing target periods.

## What was the approach?
Change the check to expect the sum of targets instead of the overall target which already exists.

## Are there any concerns to addressed further before or after merging this PR?
None

## Mentions?
@andrewtpham 

## Issue(s) affected?
ACT-731