### PR TITLE
ISS-437: Fix invalid link message

### DIFF
--- a/activity/tokens.py
+++ b/activity/tokens.py
@@ -9,7 +9,7 @@ class TokenGenerator(PasswordResetTokenGenerator):
     def _make_hash_value(self, user, timestamp):
         return (
             six.text_type(user.pk) + six.text_type(timestamp) +
-            six.text_type(user.is_active)
+            six.text_type(user.username)
         )
 
 


### PR DESCRIPTION
## What is the Purpose?
Fix activation link invalid error when the link is accessed more than once. The invalid message only shows when the link has been manipulated

## What was the approach?
Only show invalid link when the token has been manipulated but always redirect to login when the token is valid

## Are there any concerns to addressed further before or after merging this PR?
None

## Mentions?
@odenypeter @andrewtpham @nasirhjafri 

## Issue(s) affected?
None
