### PR TITLE
ACT-482: Fix error when updating indicator data

### DIFF
--- a/indicators/views.py
+++ b/indicators/views.py
@@ -603,11 +603,11 @@ class IndicatorUpdate(UpdateView):
             for disagg in json.loads(disaggs):
                 if disagg.get('id', None) is None:
                     disagg_type = DisaggregationType.objects.create(
-                        disaggregation_type=disagg['type']
+                        disaggregation_type=disagg['disaggregation_type']
                     )
                 else:
                     disagg_type = DisaggregationType.objects.filter(id=int(disagg['id'])).first()
-                    disagg_type.disaggregation_type = disagg['type']
+                    disagg_type.disaggregation_type = disagg['disaggregation_type']
                     disagg_type.save()
 
                 # register disag to the indicator

--- a/templates/indicators/form-sections/disaggregation.html
+++ b/templates/indicators/form-sections/disaggregation.html
@@ -39,7 +39,7 @@
     $('#id_disaggregation').select2({ theme: 'bootstrap' });
     $('#id_indicator_type').select2({ theme: 'bootstrap' });
 
-    $('#id_disaggregation_types').attr('value', disagTypes);
+    $('#id_disaggregation_types').attr('value', JSON.stringify(disagTypes));
 
     // init disag types form
     initDisagTypes();
@@ -52,12 +52,12 @@
   function stringifyDisags() {
     disagTypes = [];
     for (let i = 1; i <= countDisaggTypes; i++) {
-      let disagType = { type: '', id: null, labels: [] };
+      let disagType = { disaggregation_type: '', id: null, labels: [] };
 
       // get disag type
       $(`#disagg_type_group_${i} .type`).each(function(index, elem) {
         const inputs = elem.getElementsByTagName('input');
-        disagType.type = $(inputs[0]).val();
+        disagType.disaggregation_type = $(inputs[0]).val();
         disagType.id = $(inputs[1]).val() || null;
       });
 


### PR DESCRIPTION
## What is the Purpose?
Fix JSON decoding error that occurs when trying to update an Indicator that has existing disaggregations.

## What was the approach?
Add a `JSON.stringfy` to the data being passed to the backend, this will allow the full object to be sent back and then decoded successfully by the backend. The previous implementation returned a representation of the object that could not be decoded in the backend.

## Are there any concerns to addressed further before or after merging this PR?
None

## Mentions?
@odenypeter @andrewtpham @TAnas0 

## Issue(s) affected?
#482 
#455 