### PR TITLE
ACT-483: Fix defect that occurs after editing a result.

### DIFF
--- a/static/vue.js/collected_data_table.js
+++ b/static/vue.js/collected_data_table.js
@@ -246,6 +246,7 @@ $(document).ready(() => {
                     }
                   })
                   this.isEdit = false;
+                  this.currentResult = null;
                   this.modalHeader = 'Add Result';
                   this.toggleResultModal();
                 }


### PR DESCRIPTION
## What is the Purpose?
Fix defect that occurs when trying to add a result after editing a different one.

## What was the approach?
After updating a result, the `currentResult` should be set to `null` to prevent affecting the next result to be entered

## Are there any concerns to addressed further before or after merging this PR?
None

## Mentions?
@andrewtpham 

## Issue(s) affected?
#483 