### PR TITLE
ISS-481: Fix host identification issue on links from server

### DIFF
--- a/activity/settings/base.py
+++ b/activity/settings/base.py
@@ -420,3 +420,6 @@ MAP_WIDGETS = {
 
 SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = os.environ.get("SOCIAL_AUTH_GOOGLE_OAUTH2_KEY")
 SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET =  os.environ.get("SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET")
+
+# header setting for is_secure method on request object behavior control
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')


### PR DESCRIPTION
## What is the Purpose?
After a user is done registering, the confirmation email and any other email notification they receive should use the HTTPS protocol instead of HTTP for security.

## What was the approach?
set a variable in base.py that instructs the is_secure method to read https from our server and to trust the X-Forwarded-Proto header that comes from our proxy, and any time its value is 'https', then the request is guaranteed to be secure.

## Are there any concerns to addressed further before or after merging this PR?
Test from activity-dev-tests.hikaya.dev

## Mentions
@Kimaiyo077 @TAnas0 

## Issue(s) affected?
None

## screenshot
![https](https://user-images.githubusercontent.com/16937341/84139644-eab81d00-aa58-11ea-9e7c-9b223aca2049.png)
