### PR TITLE
Fix doctl install error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,4 +46,5 @@ jobs:
     - script:
       - export FILE_PATH="/home/travis/.docker/config.json"
       - chmod +x ci-scripts/deployment.sh
+      - sudo apt-get install snapd -y
       - ./ci-scripts/deployment.sh


### PR DESCRIPTION
## What is the Purpose?
Fix doctl install error on travis, The error was causing deployments on travis to fail.

## What was the approach?
Update snapd before installing doctl to avoid error while job tries to fetch doctl

## Are there any concerns to addressed further before or after merging this PR?
None

## Mentions?
@Kimaiyo077 

## Issue(s) affected?
None