### PR TITLE
Fix: The "End of Program " column should use the Overall Target value

### DIFF
--- a/reports/views.py
+++ b/reports/views.py
@@ -323,7 +323,6 @@ class GenerateReport(View):
                                                             .order_by('customsort')
             indicator = IndicatorSerializer(ind).data,
             periodic_data = PeriodicTargetSerializer(periodic_targets, many=True).data
-            total_targeted = 0
             total_achieved = 0
 
             for data in indicator:
@@ -331,6 +330,7 @@ class GenerateReport(View):
                 program = data['program'][0]
                 start_date = program['start_date']
                 end_date = program['end_date']
+                total_targeted = float(data['lop_target'])
 
             start = pendulum.parse(start_date)
             end = pendulum.parse(end_date)
@@ -340,7 +340,6 @@ class GenerateReport(View):
             for data in periodic_data:
                 for collecteddata in data['collecteddata_set']:
                     total_achieved += float(collecteddata['achieved'])
-                    total_targeted += float(collecteddata['targeted'])
 
             current = None
             previous = None


### PR DESCRIPTION
## What is the Purpose?
Fixes issue #645 

## What was the approach?
 The issue was coming from reports/views in the GenerateReport view, the total_targeted should be derived from the lop_target of an indicator instead of being added from the target periods being reported. Fixed this based on @Kimaiyo077 's comment

## Are there any concerns to addressed further before or after merging this PR?
None

## Mentions?
@Kimaiyo077 @andrewtpham 

## Issue(s) affected?
#645 