### PR TITLE
docs: Add Python version in Virtualenv Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ $ pip install virtualenv
 #### Create virtualenv
 
 ```bash
-$ virtualenv <myvirtualenvironmentname>
+$ virtualenv -p python3.7 <myvirtualenvironmentname>
 ```
 
 - by default it should prevent virtualenv from seeing your global packages


### PR DESCRIPTION
## What is the Purpose?
`python3` can point to different versions depending on what python3 defaults to on someone's OS. It's better if we pass the specific python version along with the `virtualenv` command to make sure we don't run into some unnecessary bugs.

## What was the approach?
Use `-p` provided by `virtualenv`

## Issue(s) affected?
Fixes #651 
