### PR TITLE
fix: remove preview text from email template

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -258,6 +258,11 @@ nav>div>.container {
   margin-bottom: -20px;
 }
 
+.alert-password-success {
+  margin-top: 16px;
+  margin-bottom: 0px;
+}
+
 #footer > .container {
   padding: 10px;
 }

--- a/templates/emails/invite.html
+++ b/templates/emails/invite.html
@@ -521,9 +521,6 @@
     </style>
   </head>
   <body>
-    <!--*|IF:MC_PREVIEW_TEXT|*-->
-    <!--[if !gte mso 9]><!----><span class="mcnPreviewText" style="display:none; font-size:0px; line-height:0px; max-height:0px; max-width:0px; opacity:0; overflow:hidden; visibility:hidden; mso-hide:all;">*|MC_PREVIEW_TEXT|*</span><!--<![endif]-->
-    <!--*|END:IF|*-->
     <center>
       <table align="center" border="0" cellpadding="0" cellspacing="0" height="100%" width="100%" id="bodyTable">
         <tr>

--- a/templates/emails/registration/email_confirmation.html
+++ b/templates/emails/registration/email_confirmation.html
@@ -522,9 +522,6 @@
     <script>var w=window;if(w.performance||w.mozPerformance||w.msPerformance||w.webkitPerformance){var d=document;AKSB=w.AKSB||{},AKSB.q=AKSB.q||[],AKSB.mark=AKSB.mark||function(e,_){AKSB.q.push(["mark",e,_||(new Date).getTime()])},AKSB.measure=AKSB.measure||function(e,_,t){AKSB.q.push(["measure",e,_,t||(new Date).getTime()])},AKSB.done=AKSB.done||function(e){AKSB.q.push(["done",e])},AKSB.mark("firstbyte",(new Date).getTime()),AKSB.prof={custid:"641052",ustr:"",originlat:"0",clientrtt:"15",ghostip:"2.22.10.129",ipv6:false,pct:"10",clientip:"79.224.119.179",requestid:"1bbbd62c",region:"23951",protocol:"h2",blver:14,akM:"x",akN:"ae",akTT:"O",akTX:"1",akTI:"1bbbd62c",ai:"493573",ra:"false",pmgn:"",pmgi:"",pmp:"",qc:""},function(e){var _=d.createElement("script");_.async="async",_.src=e;var t=d.getElementsByTagName("script"),t=t[t.length-1];t.parentNode.insertBefore(_,t)}(("https:"===d.location.protocol?"https:":"http:")+"//ds-aksb-a.akamaihd.net/aksb.min.js")}</script>
   </head>
   <body>
-    <!--*|IF:MC_PREVIEW_TEXT|*-->
-    <!--[if !gte mso 9]><!----><span class="mcnPreviewText" style="display:none; font-size:0px; line-height:0px; max-height:0px; max-width:0px; opacity:0; overflow:hidden; visibility:hidden; mso-hide:all;">*|MC_PREVIEW_TEXT|*</span><!--<![endif]-->
-    <!--*|END:IF|*-->
     <center>
       <table align="center" border="0" cellpadding="0" cellspacing="0" height="100%" width="100%" id="bodyTable">
       <tr>

--- a/templates/emails/registration/welcome.html
+++ b/templates/emails/registration/welcome.html
@@ -547,9 +547,6 @@
 
 }</style></head>
     <body>
-        <!--*|IF:MC_PREVIEW_TEXT|*-->
-        <!--[if !gte mso 9]><!----><span class="mcnPreviewText" style="display:none; font-size:0px; line-height:0px; max-height:0px; max-width:0px; opacity:0; overflow:hidden; visibility:hidden; mso-hide:all;">*|MC_PREVIEW_TEXT|*</span><!--<![endif]-->
-        <!--*|END:IF|*-->
         <center>
             <table align="center" border="0" cellpadding="0" cellspacing="0" height="100%" width="100%" id="bodyTable">
                 <tr>

--- a/templates/registration/password_reset_done.html
+++ b/templates/registration/password_reset_done.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 <div class="container">
     <br><br><br>
-    <div class="alert alert-success" role="alert">
+    <div class="alert-success alert-password-success" role="alert">
         <p><strong>{% trans 'Success' %}!</strong></p>
         <p>
             {% trans 'An email has been sent with instructions to reset your password.' %}

--- a/templates/registration/password_reset_email.html
+++ b/templates/registration/password_reset_email.html
@@ -548,9 +548,6 @@
 
 }</style></head>
     <body>
-        <!--*|IF:MC_PREVIEW_TEXT|*-->
-        <!--[if !gte mso 9]><!----><span class="mcnPreviewText" style="display:none; font-size:0px; line-height:0px; max-height:0px; max-width:0px; opacity:0; overflow:hidden; visibility:hidden; mso-hide:all;">*|MC_PREVIEW_TEXT|*</span><!--<![endif]-->
-        <!--*|END:IF|*-->
         <center>
             <table align="center" border="0" cellpadding="0" cellspacing="0" height="100%" width="100%" id="bodyTable">
                 <tr>


### PR DESCRIPTION
## What is the Purpose?
fix: remove preview text from email template

## What was the approach?
remove "MC_PREVIEW_TEXT" from the email template

## Are there any concerns to addressed further before or after merging this PR?
None

## Mentions?
@andrewtpham 

## Issue(s) affected?
None