### PR TITLE
ACT-435: Add sticky footer

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -40,6 +40,10 @@ a:focus, a:hover {
   border-radius: 0;
 }
 
+/* Push footer to bottom of page */
+.activity-content {
+    min-height: calc(100vh - 120px);
+}
 
 #footer {
   /* bottom: 0; */


### PR DESCRIPTION
## What is the Purpose?
The footer would not stay at the bottom of the viewport if the content in the page was shorter than the viewport's height.

## What was the approach?
I gave the sibling element of the footer, a div with class `.activity-content` a `min-height: calc(100vh - 120px);`. This forces the `.activity-content` element to expand when the viewport is larger than the contents. It also allows the footer to sit normally at the bottom of the page when the content is larger than the viewport
```css
/* Push footer to bottom of page */
.activity-content {
    min-height: calc(100vh - 120px);
}
```

## Are there any concerns to addressed further before or after merging this PR?
After checking all of the pages in Activity, I found that the following two have a slightly different DOM layout, and so they are unaffected by this CSS change.
Workflows (from the top menu) > Projects - URL: `http://127.0.0.1:8000//workflow/level2/list/0/none/`
Components (from the top menu) > Documents - URL: `http://127.0.0.1:8000//workflow/documentation_list/0/0/`
<img width="511" alt="Activity-Pull-Request-Abnormal" src="https://user-images.githubusercontent.com/44626877/96613523-58c1fa00-12ff-11eb-83ad-13f6c3d2883e.png">
<img width="509" alt="Activity-Pull-Request-Normal" src="https://user-images.githubusercontent.com/44626877/96613916-cff78e00-12ff-11eb-8631-fde2f3c29506.png">

## Mentions?
@andrewtpham - Thanks for assigning this Issue. Please let me know if I can clarify anything.

## Issue(s) affected?
#435 
