### PR TITLE
fixed sticky footer for project and documents page (issue #716)

### DIFF
--- a/templates/admin/map_settings.html
+++ b/templates/admin/map_settings.html
@@ -109,6 +109,7 @@
                         placeholder="Zoom"
                         @keyUp=getBoundaryData(admin_boundary)
                         />
+                    <span class="help-block">Select a zoom level between 1-18 (whole number only) for the map.</span>
                 </div>
             </div>
             <div class="row">

--- a/templates/workflow/documentation_list.html
+++ b/templates/workflow/documentation_list.html
@@ -131,7 +131,7 @@
     </tbody>
   </table>
 
-
+</div>
 
   <!-- add document modal -->
 

--- a/templates/workflow/projectdashboard_list.html
+++ b/templates/workflow/projectdashboard_list.html
@@ -88,7 +88,7 @@
     {% endif %}{% endfor %}
   </tbody>
   </table>
-  <table>
+
 
   <script type="text/javascript">
     function program_filter(program_id) {


### PR DESCRIPTION
## What is the Purpose?
The footer for the project and documents page would not stay at the bottom of the page.

## What was the approach?
There was an unclosed `</div>` tag in `documentation_list.html` and an open `<table>` tag in `projectdashboard_list.html`


## Are there any concerns to addressed further before or after merging this PR?
None

## Mentions?
@andrewtpham @ninetteadhikari @TAnas0 

## Issue(s) affected?
Issue #716
