### PR TITLE
Fix installation of `cryptography` PIP package in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,12 @@ ENV ACTIVITY_CE_DB_PASSWORD=activity
 ENV ACTIVITY_CE_DB_HOST=db
 ENV ACTIVITY_CE_DB_PORT=5432
 
+# Fix of https://github.com/pyca/cryptography/issues/5771
+# starting cryptography>=3.5, Rust is required to build it (or a later version of PIP for wheel download)
+# Updating cryptography requries Rust installation
+# In cryptography < 3.5, which we use, it can be disabled using the below env var
+ENV CRYPTOGRAPHY_DONT_BUILD_RUST=1
+
 # Install dependencies
 RUN pip install --upgrade pip
 COPY ./requirements.txt /usr/src/activity/requirements.txt


### PR DESCRIPTION
## What is the Purpose?
Fix the Docker build image step occuring on Github Actions: https://github.com/hikaya-io/activity/actions/runs/1158606024
Issue is during the PIP packages install, more specifically the `cryptography` package, which is not a direct dependency of ours (through `pendulum` package)

## What was the approach?
Since we are using `cryptography<3.5`, we can just disable the Rust build during the install using an environment variable: https://github.com/pyca/cryptography/issues/5771#issuecomment-775016788

The whole Github issue also addresses how to install Rust if we want to upgrade `cryptography`


## Are there any concerns to addressed further before or after merging this PR?
None

## Mentions?
@michaelbukachi 

## Issue(s) affected?
None