### PR TITLE
Disable deploy stage on `develop` branch

### DIFF
--- a/.github/workflows/activity_ci_cd.yml
+++ b/.github/workflows/activity_ci_cd.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches:
       - develop
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
   release:
     types:
       - published

--- a/.github/workflows/activity_ci_cd.yml
+++ b/.github/workflows/activity_ci_cd.yml
@@ -140,7 +140,7 @@ jobs:
   Deploy:
     needs: Build_and_push_image
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/develop' || github.event_name == 'release'
+    if: github.event_name == 'release'
     container:
       image: yagami22/ci-deploy-image
     steps:


### PR DESCRIPTION
## What is the Purpose?
1. Since we moved to the new K8s cluster for Activity Dev, we don't need to trigger the deployment from our CI. We need this only for the legacy production cluster.
2. Configured Github Actions to ignore PRs limited to documentation and Markdown files, to avoid unnecessary GA runs

## What was the approach?
All edits are in the GA YAML file

## Are there any concerns to addressed further before or after merging this PR?
None

## Mentions?
@andrewtpham 

## Issue(s) affected?
None
