### PR TITLE
fix(email): correct link in confirmation email

### DIFF
--- a/templates/emails/registration/email_confirmation.html
+++ b/templates/emails/registration/email_confirmation.html
@@ -954,7 +954,7 @@
                                   <a
                                     class="mcnButton"
                                     title="Confirm email"
-                                    href="{{BASE_URL}}/activate/{{activation_key}}"
+                                    href="{{domain}}/activate/{{uid}}/{{token}}/"
                                     target="_blank"
                                     style="
                                       font-weight: bold;


### PR DESCRIPTION
## What is the Purpose?
Correct the link in the email confirmation email.
I suspect this to be breaking the Activity E2E tests

## What was the approach?
Replaced the link with the variables passed to the email template

## Are there any concerns to addressed further before or after merging this PR?
Once deployed, do a manual check

## Mentions?
None

## Issue(s) affected?
None
